### PR TITLE
Escape reserved words

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "small-swagger-codegen",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "small-swagger-codegen",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "A small version of swagger-codegen. Does fewer things with less code.",
   "main": "./build/small-swagger-codegen.js",
   "scripts": {

--- a/src/templateDatasFromSpecs.js
+++ b/src/templateDatasFromSpecs.js
@@ -54,9 +54,9 @@ function nameFromComponents(...components) {
   const nonNumberName = Number.isNaN(Number(name[0])) ? name : `_${name}`;
   // Names that are reserved words would be escaped.
   return [
-      'default',
-      'as'
-  ].includes(nonNumberName) ? `\`${nonNumberName}\`` : nonNumberName
+    'default',
+    'as',
+  ].includes(nonNumberName) ? `\`${nonNumberName}\`` : nonNumberName;
 }
 
 // Create a class name by combining the given component strings.


### PR DESCRIPTION
A case for an enum in POI API was named `as`, causing to fail to compile. This change will escape names that are the same as some swift reserved words.