### PR TITLE
remove header map. no longer needed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "small-swagger-codegen",
-  "version": "1.16.9",
+  "version": "1.17.0",
   "description": "A small version of swagger-codegen. Does fewer things with less code.",
   "main": "./build/small-swagger-codegen.js",
   "scripts": {

--- a/src/kotlin/template.handlebars
+++ b/src/kotlin/template.handlebars
@@ -49,7 +49,6 @@ class {{{apiClassName}}} : GBIORxWebServices() {
         {{/if}}
         @JvmSuppressWildcards
         fun {{{name}}}(
-            @HeaderMap headerMap: Map<String, String>{{#if params.length}},{{/if}}
         {{#each params}}
             @{{{inCap}}}{{#isNotBodyOrPartParam this}}("{{{serverName}}}"){{/isNotBodyOrPartParam}} {{{name}}}: {{{type}}}{{#unless required}}? = null{{/unless}}{{~#unless @last}},{{/unless}}
         {{/each}}

--- a/tests/snapshots/FeatureAPI.kt
+++ b/tests/snapshots/FeatureAPI.kt
@@ -41,7 +41,6 @@ class FeatureAPI : GBIORxWebServices() {
         @POST("/feature/features/{tag_name}")
         @JvmSuppressWildcards
         fun getFeatures(
-            @HeaderMap headerMap: Map<String, String>,
             @Path("tag_name") tagName: String,
             @Query("sample_query") sampleQuery: String? = null,
             @Body client: ClientData
@@ -55,7 +54,6 @@ class FeatureAPI : GBIORxWebServices() {
         @GET("/feature/noargs")
         @JvmSuppressWildcards
         fun noargsGet(
-            @HeaderMap headerMap: Map<String, String>
         ) : Single<Features>
     }
     //endregion


### PR DESCRIPTION
We have moved all auth header logic to a centralized place and no longer need it as part of the retrofit interfaces.